### PR TITLE
add as backup mac and linux bundler packages

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,8 +119,6 @@ GEM
     nokogiri (1.11.1)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
-    nokogiri (1.11.1-x86_64-linux)
-      racc (~> 1.4)
     orm_adapter (0.5.0)
     pg (1.2.3)
     pry (0.13.1)
@@ -234,6 +232,9 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-darwin-20
+  x86_64-linux
+
 DEPENDENCIES
   autoprefixer-rails
   bootsnap (>= 1.4.2)


### PR DESCRIPTION
add as backup the bundler platform darwin for mac and linux for linux & windows - now your app should work on the following bundler platforms:

Your app has gems that work on these platforms:
* ruby
* x86_64-darwin-20
* x86_64-linux

